### PR TITLE
Distinguish between inner and outer M3U playlists.

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/playlists/HlsStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/playlists/HlsStreamSegmentUrlProvider.java
@@ -3,6 +3,7 @@ package com.sedmelluq.discord.lavaplayer.container.playlists;
 import com.sedmelluq.discord.lavaplayer.source.stream.M3uStreamSegmentUrlProvider;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -28,6 +29,10 @@ public class HlsStreamSegmentUrlProvider extends M3uStreamSegmentUrlProvider {
     return "default";
   }
 
+  protected boolean isSegmentPlaylist(String[] lines) {
+    return Arrays.stream(lines).noneMatch(line -> line.startsWith("#EXT-X-STREAM-INF"));
+  }
+
   @Override
   protected String fetchSegmentPlaylistUrl(HttpInterface httpInterface) throws IOException {
     if (segmentPlaylistUrl != null) {
@@ -35,8 +40,15 @@ public class HlsStreamSegmentUrlProvider extends M3uStreamSegmentUrlProvider {
     }
 
     HttpUriRequest request = new HttpGet(streamListUrl);
-    List<ChannelStreamInfo> streams = loadChannelStreamsList(fetchResponseLines(httpInterface, request,
-        "HLS stream list"));
+
+    String[] lines = fetchResponseLines(httpInterface, request, "HLS stream list");
+
+    if (isSegmentPlaylist(lines)) {
+      return (segmentPlaylistUrl = streamListUrl);
+    }
+
+    List<ChannelStreamInfo> streams = loadChannelStreamsList(
+        fetchResponseLines(httpInterface, request, "HLS stream list"));
 
     if (streams.isEmpty()) {
       throw new IllegalStateException("No streams listed in HLS stream list.");

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/playlists/HlsStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/playlists/HlsStreamSegmentUrlProvider.java
@@ -47,8 +47,7 @@ public class HlsStreamSegmentUrlProvider extends M3uStreamSegmentUrlProvider {
       return (segmentPlaylistUrl = streamListUrl);
     }
 
-    List<ChannelStreamInfo> streams = loadChannelStreamsList(
-        fetchResponseLines(httpInterface, request, "HLS stream list"));
+    List<ChannelStreamInfo> streams = loadChannelStreamsList(lines);
 
     if (streams.isEmpty()) {
       throw new IllegalStateException("No streams listed in HLS stream list.");

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
@@ -166,7 +166,7 @@ public abstract class M3uStreamSegmentUrlProvider {
         }
 
         streamInfoLine = null;
-      } else if (line.isDirective() && ("EXT-X-STREAM-INF".equals(line.directiveName))) { //|| "EXTINF".equals(line.directiveName))) {
+      } else if (line.isDirective() && ("EXT-X-STREAM-INF".equals(line.directiveName) || "EXTINF".equals(line.directiveName))) {
         streamInfoLine = line;
       }
     }


### PR DESCRIPTION
Avoid loading an inner playlist as an outer one if we detect a directive commonly found in outer playlists.

This may not be a foolproof solution but it should suffice.
