### PR TITLE
Validate subformats when wav format is `WAVE_FORMAT_EXTENSIBLE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Changed
 - Changed `WavTrackProvider` to not needlessly recalculate `bytesPerSample`
+- Changed `WavFileLoader` to validate subformats when the format is `WAVE_FORMAT_EXTENSIBLE`.
 - Changed `YoutubeAudioSourceManager` to throw an exception when trying to load a user's automatically generated playlists.
   - These are playlists like `LL` (liked videos), `WL` (watch later), `LM` and `RDMM`. These cannot be accessed without some form of oauth integration.
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/wav/WaveFormatType.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/wav/WaveFormatType.java
@@ -1,0 +1,21 @@
+package com.sedmelluq.discord.lavaplayer.container.wav;
+
+import java.util.Arrays;
+
+public enum WaveFormatType {
+    // https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/Docs/Pages%20from%20mmreg.h.pdf
+    WAVE_FORMAT_UNKNOWN(0x0000),
+    WAVE_FORMAT_PCM(0x0001),
+    WAVE_FORMAT_EXTENSIBLE(0xFFFE);
+
+    final int code;
+
+    WaveFormatType(int code) {
+        this.code = code;
+    }
+
+    static WaveFormatType getByCode(int code) {
+        return Arrays.stream(values()).filter(type -> type.code == code).findFirst()
+            .orElse(WAVE_FORMAT_UNKNOWN);
+    }
+}


### PR DESCRIPTION
This change patches the `WavFileLoader` to validate subformats if the chunk format is `WAVE_FORMAT_EXTENSIBLE`. This should make the library a little more robust when it comes to decoding wave files, as it won't try to unknowingly load unsupported subformats.