### PR TITLE
Add support for gapless playback

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/AudioPlayer.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/AudioPlayer.java
@@ -10,9 +10,16 @@ import com.sedmelluq.discord.lavaplayer.track.playback.AudioFrameProvider;
  */
 public interface AudioPlayer extends AudioFrameProvider {
   /**
-   * @return Currently playing track
+   * @return Currently playing track, or null
    */
   AudioTrack getPlayingTrack();
+
+  /**
+   * @return Currently scheduled track, or null
+   */
+  default AudioTrack getScheduledTrack() {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * @param track The track to start playing
@@ -27,9 +34,28 @@ public interface AudioPlayer extends AudioFrameProvider {
   boolean startTrack(AudioTrack track, boolean noInterrupt);
 
   /**
-   * Stop currently playing track.
+   * Schedules the next track to be played. This will not trigger the track to be immediately played,
+   * but rather schedules it to play after the current track has finished. If there is no playing track,
+   * this function will return false
+   * @param track The track to schedule. This will overwrite the currently scheduled track, if one exists.
+   *              Passing null will clear the current scheduled track.
+   * @return True if the track was scheduled
+   */
+  default boolean scheduleTrack(AudioTrack track) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Stop currently playing track. This will also clear any scheduled tracks.
    */
   void stopTrack();
+
+  /**
+   * Stop currently playing track.
+   */
+  default void stopCurrentTrack() {
+    throw new UnsupportedOperationException();
+  }
 
   int getVolume();
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
@@ -166,7 +166,7 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
         scheduledTrack = null;
       }
 
-      // There's a fair amount of redundant/duplicated checks here so I need to improve
+      // There's a fair amount of redundant/duplicated checks here, so I need to improve
       // this at some point.
       boolean setScheduledTrack = false;
       InternalAudioTrack previousTrack = activeTrack;
@@ -184,6 +184,8 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
 
       if (setScheduledTrack) {
         dispatchEvent(new TrackStartEvent(this, activeTrack));
+      } else {
+        activeTrack = null;
       }
     }
   }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
@@ -310,11 +310,14 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
             ? (failedBeforeLoad ? LOAD_FAILED_GAPLESS : FINISHED_GAPLESS)
             : (failedBeforeLoad ? LOAD_FAILED : FINISHED);
 
-        dispatchEvent(new TrackEndEvent(this, track, endReason));
-
         if (scheduledTrack != null) {
           activeTrack = scheduledTrack;
           scheduledTrack = null;
+        }
+
+        dispatchEvent(new TrackEndEvent(this, track, endReason));
+
+        if (activeTrack != null) {
           dispatchEvent(new TrackStartEvent(this, activeTrack));
         }
       }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
@@ -25,6 +25,7 @@ import static com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason.*;
 public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
   private static final Logger log = LoggerFactory.getLogger(AudioPlayer.class);
 
+  private volatile InternalAudioTrack scheduledTrack;
   private volatile InternalAudioTrack activeTrack;
   private volatile long lastRequestTime;
   private volatile long lastReceiveTime;
@@ -49,10 +50,44 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
   }
 
   /**
-   * @return Currently playing track
+   * @return Currently playing track, or null
    */
   public AudioTrack getPlayingTrack() {
     return activeTrack;
+  }
+
+  /**
+   * @return Currently scheduled track, or null
+   */
+  public AudioTrack getScheduledTrack() {
+    return scheduledTrack;
+  }
+
+  /**
+   * Schedules the next track to be played. This will not trigger the track to be immediately played,
+   * but rather schedules it to play after the current track has finished. If there is no playing track,
+   * this function will return false
+   * @param track The track to schedule. This will overwrite the currently scheduled track, if one exists.
+   *              Passing null will clear the current scheduled track.
+   * @return True if the track was scheduled
+   */
+  public boolean scheduleTrack(AudioTrack track) {
+    if (activeTrack == null) {
+      return false;
+    }
+
+    synchronized (trackSwitchLock) {
+      if (scheduledTrack != null) {
+        scheduledTrack.stop();
+      }
+
+      InternalAudioTrack newTrack = (InternalAudioTrack) track;
+      scheduledTrack = newTrack;
+
+      manager.executeTrack(this, newTrack, manager.getConfiguration(), options);
+    }
+
+    return true;
   }
 
   /**
@@ -63,6 +98,7 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
   }
 
   /**
+   * Starts a new track. This will clear any scheduled tracks.
    * @param track The track to start playing, passing null will stop the current track and return false
    * @param noInterrupt Whether to only start if nothing else is playing
    * @return True if the track was started
@@ -76,6 +112,11 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
 
       if (noInterrupt && previousTrack != null) {
         return false;
+      }
+
+      if (scheduledTrack != null) {
+        scheduledTrack.stop();
+        scheduledTrack = null;
       }
 
       activeTrack = newTrack;
@@ -105,14 +146,26 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
   /**
    * Stop currently playing track.
    */
-  public void stopTrack() {
-    stopWithReason(STOPPED);
+  public void stopCurrentTrack() {
+    stopWithReason(STOPPED, false);
   }
 
-  private void stopWithReason(AudioTrackEndReason reason) {
+  /**
+   * Stop currently playing track and any scheduled tracks.
+   */
+  public void stopTrack() {
+    stopWithReason(STOPPED, true);
+  }
+
+  private void stopWithReason(AudioTrackEndReason reason, boolean includeScheduled) {
     shadowTrack = null;
 
     synchronized (trackSwitchLock) {
+      if (includeScheduled && scheduledTrack != null) {
+        scheduledTrack.stop();
+        scheduledTrack = null;
+      }
+
       InternalAudioTrack previousTrack = activeTrack;
       activeTrack = null;
 
@@ -241,7 +294,24 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
       if (activeTrack == track) {
         activeTrack = null;
 
-        dispatchEvent(new TrackEndEvent(this, track, track.getActiveExecutor().failedBeforeLoad() ? LOAD_FAILED : FINISHED));
+        boolean failedBeforeLoad = track.getActiveExecutor().failedBeforeLoad();
+        AudioTrackEndReason endReason;
+
+        // this could probably be better...
+        if (scheduledTrack != null) {
+          endReason = failedBeforeLoad ? LOAD_FAILED_GAPLESS : FINISHED_GAPLESS;
+        }  else {
+          endReason = failedBeforeLoad ? LOAD_FAILED : FINISHED;
+        }
+
+        dispatchEvent(new TrackEndEvent(this, track, endReason));
+
+        if (scheduledTrack != null) {
+          activeTrack = scheduledTrack;
+          scheduledTrack = null;
+
+          dispatchEvent(new TrackStartEvent(this, activeTrack));
+        }
       }
     }
   }
@@ -370,7 +440,7 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
     if (track != null && System.currentTimeMillis() - lastRequestTime >= threshold) {
       log.debug("Triggering cleanup on an audio player playing track {}", track);
 
-      stopWithReason(CLEANUP);
+      stopWithReason(CLEANUP, true);
     }
   }
 }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
@@ -166,15 +166,13 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
         scheduledTrack = null;
       }
 
-      // There's a fair amount of redundant/duplicated checks here, so I need to improve
-      // this at some point.
-      boolean setScheduledTrack = false;
       InternalAudioTrack previousTrack = activeTrack;
 
       if (scheduledTrack != null) {
         activeTrack = scheduledTrack;
         scheduledTrack = null;
-        setScheduledTrack = true;
+      } else {
+        activeTrack = null;
       }
 
       if (previousTrack != null) {
@@ -182,10 +180,8 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
         dispatchEvent(new TrackEndEvent(this, previousTrack, reason));
       }
 
-      if (setScheduledTrack) {
+      if (activeTrack != null) {
         dispatchEvent(new TrackStartEvent(this, activeTrack));
-      } else {
-        activeTrack = null;
       }
     }
   }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/track/AudioTrackEndReason.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/track/AudioTrackEndReason.java
@@ -5,6 +5,16 @@ package com.sedmelluq.discord.lavaplayer.track;
  */
 public enum AudioTrackEndReason {
   /**
+   * This is similar to {@link #FINISHED}, but a new track was immediately started -- typically the one scheduled
+   * with {@link com.sedmelluq.discord.lavaplayer.player.AudioPlayer#scheduleTrack}
+   */
+  FINISHED_GAPLESS(false),
+  /**
+   * This is similar to {@link #LOAD_FAILED}, but a new track was immediately started -- typically the one scheduled
+   * with {@link com.sedmelluq.discord.lavaplayer.player.AudioPlayer#scheduleTrack}
+   */
+  LOAD_FAILED_GAPLESS(false),
+  /**
    * This means that the track itself emitted a terminator. This is usually caused by the track reaching the end,
    * however it will also be used when it ends due to an exception.
    */


### PR DESCRIPTION
This PR adds support for gapless playback. This means that the player can switch to a second track (provided it has been scheduled) with virtually no pause during the switch, allowing for seamless playback for tracks that support it.