### PR TITLE
fix: add LavaSrc compatibility

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/track/AudioTrackInfo.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/track/AudioTrackInfo.java
@@ -28,6 +28,35 @@ public class AudioTrackInfo {
    * URL of the track, or local path to the file.
    */
   public final String uri;
+  /**
+   * URL to thumbnail of the track
+   */
+  public final String artworkUrl;
+  /**
+   * International Standard Recording Code
+   */
+  public final String isrc;
+
+  /**
+   * @param title      Track title
+   * @param author     Track author, if known
+   * @param length     Length of the track in milliseconds
+   * @param identifier Audio source specific track identifier
+   * @param isStream   True if this track is a stream
+   * @param uri        URL of the track or path to its file.
+   * @param artworkUrl Thumbnail of the track
+   * @param isrc       International Standard Recording Code
+   */
+  public AudioTrackInfo(String title, String author, long length, String identifier, boolean isStream, String uri, String artworkUrl, String isrc) {
+    this.title = title;
+    this.author = author;
+    this.length = length;
+    this.identifier = identifier;
+    this.isStream = isStream;
+    this.uri = uri;
+    this.artworkUrl = artworkUrl;
+    this.isrc = isrc;
+  }
 
   /**
    * @param title Track title
@@ -38,11 +67,6 @@ public class AudioTrackInfo {
    * @param uri URL of the track or path to its file.
    */
   public AudioTrackInfo(String title, String author, long length, String identifier, boolean isStream, String uri) {
-    this.title = title;
-    this.author = author;
-    this.length = length;
-    this.identifier = identifier;
-    this.isStream = isStream;
-    this.uri = uri;
+    this(title, author, length, identifier, isStream, uri, null, null);
   }
 }


### PR DESCRIPTION
yes (fixes error below)

```
Caused by: java.lang.NoSuchMethodError: 'void com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo.<init>(java.lang.String, java.lang.String, long, java.lang.String, boolean, java.lang.String, java.lang.String, java.lang.String)'
	at com.github.topi314.lavasrc.spotify.SpotifySourceManager.parseTrack(SpotifySourceManager.java:557)
	at com.github.topi314.lavasrc.spotify.SpotifySourceManager.parseTrackItems(SpotifySourceManager.java:542)
	at com.github.topi314.lavasrc.spotify.SpotifySourceManager.getSearch(SpotifySourceManager.java:378)
	at com.github.topi314.lavasrc.spotify.SpotifySourceManager.loadItem(SpotifySourceManager.java:250)
	at com.github.topi314.lavasrc.spotify.SpotifySourceManager.loadItem(SpotifySourceManager.java:244)
	at com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager.checkSourcesForItemOnce(DefaultAudioPlayerManager.java:414)
	at com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager.checkSourcesForItem(DefaultAudioPlayerManager.java:396)
	at com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager.lambda$createItemLoader$0(DefaultAudioPlayerManager.java:195)```